### PR TITLE
use the previous AzureRM version instead of latest 5.0.0 because the …

### DIFF
--- a/frontend/new-admin-vm/Install-CAM.ps1
+++ b/frontend/new-admin-vm/Install-CAM.ps1
@@ -614,7 +614,9 @@ Configuration InstallCAM
 				If(-not [bool](Get-InstalledModule | where {$_.Name -eq "AzureRM"}))
 				{
 					Write-Verbose "Installing AzureRM"
-					Install-Module -Name AzureRM -Force
+					#Install-Module -Name AzureRM -Force
+					Install-Module -Name AzureRM -MaximumVersion 4.4.1 -Force
+					Write-Verbose "finished Installation of AzureRM"
 				}
 				
 


### PR DESCRIPTION
…5..0.0 has a bug to cause deploy failed