### PR TITLE
Param cleanup 2

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2001,6 +2001,14 @@ function Deploy-CAM() {
 				},
 				"secretName": "cloudAccessRegistrationCode"
 			}
+        },
+        "userStorageAccountKey": {
+			"reference": {
+				"keyVault": {
+				"id": "$kvId"
+				},
+				"secretName": "userStorageAccountKey"
+			}
 		}
 	}
 }

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -40,7 +40,7 @@ param(
 	$AgentChannel = "stable",
 
     $camSaasUri = "https://cam-antar.teradici.com",
-    $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/bddc2/azuredeploy.json",
+    $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/param-cleanup-2/azuredeploy.json",
     $CAMBinariesSource = "https://teradeploy.blob.core.windows.net/bdstable",
     $outputParametersFileName = "cam-output.parameters.json",
     $location

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -323,7 +323,7 @@ function New-UserStorageAccount {
     return $acct
 }
 
-
+# is blobRWTemplateURI still needed - can pass in the userStorageAccountUri to agent ARM template
 function New-RemoteWorstationTemplates {
     param (
         $CAMConfig,
@@ -1913,7 +1913,23 @@ function Deploy-CAM() {
 				},
 				"secretName": "artifactsLocation"
 			}
-		},
+        },
+        "userStorageAccountUri": {
+			"reference": {
+				"keyVault": {
+					"id": "$kvId"
+				},
+				"secretName": "userStorageAccountUri"
+			}
+        },
+        "userStorageAccountSasToken": {
+			"reference": {
+				"keyVault": {
+					"id": "$kvId"
+				},
+				"secretName": "userStorageAccountSasToken"
+			}
+        },
 		"LocalAdminUsername": {
 			"reference": {
 				"keyVault": {

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -1848,6 +1848,24 @@ function Deploy-CAM() {
         # keyvault ID of the form: /subscriptions/$subscriptionID/resourceGroups/$azureRGName/providers/Microsoft.KeyVault/vaults/$kvName
         $kvId = $kvInfo.ResourceId
 
+        # debug null userStorageAccountUri
+        $vault = $kvInfo.VaultName
+        $secret = Get-AzureKeyVaultSecret `
+        -VaultName $vault `
+        -Name "userStorageAccountUri" `
+        -ErrorAction stop
+
+        $urisecret = $secret.SecretValueText
+        Write-Host "Stored uri secret is $urisecret..."
+
+        $secretdomain = Get-AzureKeyVaultSecret `
+        -VaultName $vault `
+        -Name "domainName" `
+        -ErrorAction stop
+        $plaindomainname = $secretdomain.SecretValueText
+        Write-Host "Stored domain name secret is $plaindomainname"
+
+
         $generatedDeploymentParameters = @"
 {
 	"`$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -40,8 +40,8 @@ param(
 	$AgentChannel = "stable",
 
     $camSaasUri = "https://cam-antar.teradici.com",
-    $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/param-cleanup-2/azuredeploy.json",
-    $binaryLocation = "https://teradeploy.blob.core.windows.net/bdstable",
+    $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/master/azuredeploy.json",
+    $binaryLocation = "https://teradeploy.blob.core.windows.net/binaries",
     $outputParametersFileName = "cam-output.parameters.json",
     $location
 )

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -41,7 +41,7 @@ param(
 
     $camSaasUri = "https://cam-antar.teradici.com",
     $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/param-cleanup-2/azuredeploy.json",
-    $CAMBinariesSource = "https://teradeploy.blob.core.windows.net/bdstable",
+    $binaryLocation = "https://teradeploy.blob.core.windows.net/bdstable",
     $outputParametersFileName = "cam-output.parameters.json",
     $location
 )
@@ -362,7 +362,7 @@ function New-RemoteWorstationTemplates {
 		"agentType": { "value": "%agentType%" },
 		"vmSize": { "value": "%vmSize%" },
 		"AgentChannel": { "value": "$agentChannel"},
-		"CAMBinariesSource": { "value": "$CAMBinariesSource" },
+		"binaryLocation": { "value": "$binaryLocation" },
 		"subnetID": { "value": "$($CAMConfig.parameters.remoteWorkstationSubnet.clearValue)" },
 		"domainUsername": { "value": "$DomainAdminUsername" },
 		"userStorageAccountName": {
@@ -508,7 +508,7 @@ function Populate-UserBlob {
         $CAMConfig,
         $artifactsLocation,
         $userDataStorageAccount,
-        $CAMBinariesSource,
+        $binaryLocation,
         $sumoAgentApplicationVM,
         $sumoConf,
         $idleShutdownLinux,
@@ -529,7 +529,7 @@ function Populate-UserBlob {
     $new_agent_vm_files = @(
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-PCoIPAgent.ps1", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-PCoIPAgent.sh", "remote-workstation"),
-        @("$CAMBinariesSource/Install-PCoIPAgent.ps1.zip", "remote-workstation"),
+        @("$binaryLocation/Install-PCoIPAgent.ps1.zip", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/sumo-agent-vm.json", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/sumo.conf", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh", "remote-workstation"),
@@ -609,7 +609,7 @@ function Populate-UserBlob {
         # blobUri is the new per-deployment blob storage location of the binaries (so a sub-directory in the container)
         New-RemoteWorstationTemplates `
             -CAMConfig $CAMConfig `
-            -binaryLocation $CAMBinariesSource `
+            -binaryLocation $binaryLocation `
             -blobRWTemplateUri ($blobUri + 'remote-workstation') `
             -kvId $kvId `
             -storageAccountContext $ctx `
@@ -1297,12 +1297,12 @@ function New-ConnectionServiceDeployment() {
                 "secretName": "gatewaySubnet"
             }
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "reference": {
                 "keyVault": {
                     "id": "$kvID"
                 },
-                "secretName": "CAMBinariesSource"
+                "secretName": "binaryLocation"
             }
         },
         "certData": {
@@ -1444,7 +1444,7 @@ function New-CAMDeploymentRoot()
     $tenant = $spInfo.tenantId
     $registrationCode = $CAMConfig.parameters.cloudAccessRegistrationCode.value
     $artifactsLocation = $CAMConfig.parameters.artifactsLocation.clearValue
-    $CAMBinariesSource = $CAMConfig.parameters.CAMBinariesSource.clearValue
+    $binaryLocation = $CAMConfig.parameters.binaryLocation.clearValue
     
     $kvInfo = New-CAM-KeyVault `
         -RGName $RGName `
@@ -1466,7 +1466,7 @@ function New-CAMDeploymentRoot()
         -CAMConfig $CAMConfig `
         -artifactsLocation $artifactsLocation `
         -userDataStorageAccount	$userDataStorageAccount `
-        -CAMBinariesSource $CAMBinariesSource `
+        -binaryLocation $binaryLocation `
         -RGName $RGName `
         -kvInfo $kvInfo `
         -tempDir $tempDir | Out-Null
@@ -1523,7 +1523,7 @@ function Deploy-CAM() {
         $camSaasUri,
 
         [parameter(Mandatory = $true)] 
-        $CAMBinariesSource,
+        $binaryLocation,
 
         [parameter(Mandatory = $true)] 
         $outputParametersFileName,
@@ -1586,9 +1586,9 @@ function Deploy-CAM() {
         value      = (ConvertTo-SecureString $domainName -AsPlainText -Force)
         clearValue = $domainName
     }
-    $CAMConfig.parameters.CAMBinariesSource = @{
-        value      = (ConvertTo-SecureString $CAMBinariesSource -AsPlainText -Force)
-        clearValue = $CAMBinariesSource
+    $CAMConfig.parameters.binaryLocation = @{
+        value      = (ConvertTo-SecureString $binaryLocation -AsPlainText -Force)
+        clearValue = $binaryLocation
     }
     $CAMConfig.parameters.artifactsLocation = @{
         value      = (ConvertTo-SecureString $artifactsLocation -AsPlainText -Force)
@@ -1898,12 +1898,12 @@ function Deploy-CAM() {
         "gatewaySubnetName": {
             "value": "$($CAMConfig.internal.GWSubnetName)"
         },
-		"CAMBinariesSource": {
+		"binaryLocation": {
 			"reference": {
 				"keyVault": {
 					"id": "$kvId"
 				},
-				"secretName": "CAMBinariesSource"
+				"secretName": "binaryLocation"
 			}
 		},
 		"_artifactsLocation": {
@@ -2326,7 +2326,7 @@ else {
         -camSaasUri $camSaasUri.Trim().TrimEnd('/') `
         -verifyCAMSaaSCertificate $verifyCAMSaaSCertificate `
         -CAMDeploymentTemplateURI $CAMDeploymentTemplateURI `
-        -CAMBinariesSource $CAMBinariesSource.Trim().TrimEnd('/') `
+        -binaryLocation $binaryLocation.Trim().TrimEnd('/') `
         -outputParametersFileName $outputParametersFileName `
         -subscriptionId $selectedSubcriptionId `
         -RGName $rgMatch.ResourceGroupName `

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2129,6 +2129,7 @@ else {
                     # Success!
                     $selectedRGName = $true
                     $rgMatch = Get-AzureRmResourceGroup -Name $rgName
+                    Write-Host "Successfully created resource group with name $rgName, $rgMatch.ResourceGroupName..."
                 }
             }
         }
@@ -2174,7 +2175,7 @@ if ($CAMRootKeyvault) {
 else {
     # New deployment - either complete or a root + Remote Workstation deployment
     # Now let's create the other required resource groups
-
+    Write-Host "Using specified resource group $rgName"
     $csRGName = $rgName + "-CS1"
     $rwRGName = $rgName + "-RW"
 

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -362,7 +362,6 @@ function New-RemoteWorstationTemplates {
 		"agentType": { "value": "%agentType%" },
 		"vmSize": { "value": "%vmSize%" },
 		"AgentChannel": { "value": "$agentChannel"},
-		"blobRWTemplateUri": { "value": "$blobRWTemplateUri" },
 		"CAMBinariesSource": { "value": "$CAMBinariesSource" },
 		"subnetID": { "value": "$($CAMConfig.parameters.remoteWorkstationSubnet.clearValue)" },
 		"domainUsername": { "value": "$DomainAdminUsername" },
@@ -373,7 +372,15 @@ function New-RemoteWorstationTemplates {
 				},
 				"secretName": "userStorageName"
 			}
-		},
+        },
+        "userStorageAccountUri": {
+			"reference": {
+				"keyVault": {
+				"id": "$kvId"
+				},
+				"secretName": "userStorageAccountUri"
+			}
+        },
 		"userStorageAccountKey": {
 			"reference": {
 				"keyVault": {
@@ -425,8 +432,7 @@ function New-RemoteWorstationTemplates {
 		},
 		"domainToJoin": { "value": "$domainFQDN" },
 		"storageAccountName": { "value": "$VHDStorageAccountName" },
-		"_artifactsLocation": { "value": "$blobRWTemplateUri" },
-		"_artifactsLocationSasToken": {
+		"userStorageAccountSasToken": {
 			"reference": {
 				"keyVault": {
 					"id": "$kvId"

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -1848,24 +1848,6 @@ function Deploy-CAM() {
         # keyvault ID of the form: /subscriptions/$subscriptionID/resourceGroups/$azureRGName/providers/Microsoft.KeyVault/vaults/$kvName
         $kvId = $kvInfo.ResourceId
 
-        # debug null userStorageAccountUri
-        $vault = $kvInfo.VaultName
-        $secret = Get-AzureKeyVaultSecret `
-        -VaultName $vault `
-        -Name "userStorageAccountUri" `
-        -ErrorAction stop
-
-        $urisecret = $secret.SecretValueText
-        Write-Host "Stored uri secret is $urisecret..."
-
-        $secretdomain = Get-AzureKeyVaultSecret `
-        -VaultName $vault `
-        -Name "domainName" `
-        -ErrorAction stop
-        $plaindomainname = $secretdomain.SecretValueText
-        Write-Host "Stored domain name secret is $plaindomainname"
-
-
         $generatedDeploymentParameters = @"
 {
 	"`$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -41,7 +41,7 @@ param(
 
     $camSaasUri = "https://cam-antar.teradici.com",
     $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/bddc2/azuredeploy.json",
-    $CAMDeploymentBlobSource = "https://teradeploy.blob.core.windows.net/bdstable",
+    $CAMBinariesSource = "https://teradeploy.blob.core.windows.net/bdstable",
     $outputParametersFileName = "cam-output.parameters.json",
     $location
 )
@@ -328,7 +328,7 @@ function New-RemoteWorstationTemplates {
     param (
         $CAMConfig,
         $binaryLocation,
-        $blobUri,
+        $blobRWTemplateUri,
         $kvId,
         $storageAccountContext,
         $storageAccountContainerName,
@@ -362,8 +362,8 @@ function New-RemoteWorstationTemplates {
 		"agentType": { "value": "%agentType%" },
 		"vmSize": { "value": "%vmSize%" },
 		"AgentChannel": { "value": "$agentChannel"},
-		"CAMDeploymentBlobSource": { "value": "$blobUri" },
-		"binaryLocation": { "value": "$binaryLocation" },
+		"blobRWTemplateUri": { "value": "$blobRWTemplateUri" },
+		"CAMBinariesSource": { "value": "$CAMBinariesSource" },
 		"subnetID": { "value": "$($CAMConfig.parameters.remoteWorkstationSubnet.clearValue)" },
 		"domainUsername": { "value": "$DomainAdminUsername" },
 		"userStorageAccountName": {
@@ -425,13 +425,13 @@ function New-RemoteWorstationTemplates {
 		},
 		"domainToJoin": { "value": "$domainFQDN" },
 		"storageAccountName": { "value": "$VHDStorageAccountName" },
-		"_artifactsLocation": { "value": "$blobUri" },
+		"_artifactsLocation": { "value": "$blobRWTemplateUri" },
 		"_artifactsLocationSasToken": {
 			"reference": {
 				"keyVault": {
 					"id": "$kvId"
 				},
-				"secretName": "userStorageAccountSaasToken"
+				"secretName": "userStorageAccountSasToken"
 			}
 		}
 	}
@@ -502,7 +502,7 @@ function Populate-UserBlob {
         $CAMConfig,
         $artifactsLocation,
         $userDataStorageAccount,
-        $CAMDeploymentBlobSource,
+        $CAMBinariesSource,
         $sumoAgentApplicationVM,
         $sumoConf,
         $idleShutdownLinux,
@@ -523,7 +523,7 @@ function Populate-UserBlob {
     $new_agent_vm_files = @(
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-PCoIPAgent.ps1", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-PCoIPAgent.sh", "remote-workstation"),
-        @("$CAMDeploymentBlobSource/Install-PCoIPAgent.ps1.zip", "remote-workstation"),
+        @("$CAMBinariesSource/Install-PCoIPAgent.ps1.zip", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/sumo-agent-vm.json", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/sumo.conf", "remote-workstation"),
         @("$artifactsLocation/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh", "remote-workstation"),
@@ -595,7 +595,7 @@ function Populate-UserBlob {
         $CAMConfig.parameters.userStorageAccountKey.value = (ConvertTo-SecureString $acctKey -AsPlainText -Force)
 
         $saSasToken = New-AzureStorageAccountSASToken -Service Blob -Resource Object -Context $ctx -ExpiryTime ((Get-Date).AddYears(2)) -Permission "racwdlup" 
-        $CAMConfig.parameters.userStorageAccountSaasToken.value = (ConvertTo-SecureString $saSasToken -AsPlainText -Force)
+        $CAMConfig.parameters.userStorageAccountSasToken.value = (ConvertTo-SecureString $saSasToken -AsPlainText -Force)
 
         # Generate and upload the parameters files
 
@@ -603,8 +603,8 @@ function Populate-UserBlob {
         # blobUri is the new per-deployment blob storage location of the binaries (so a sub-directory in the container)
         New-RemoteWorstationTemplates `
             -CAMConfig $CAMConfig `
-            -binaryLocation $CAMDeploymentBlobSource `
-            -blobUri ($blobUri + 'remote-workstation') `
+            -binaryLocation $CAMBinariesSource `
+            -blobRWTemplateUri ($blobUri + 'remote-workstation') `
             -kvId $kvId `
             -storageAccountContext $ctx `
             -storageAccountContainerName $container_name `
@@ -1054,7 +1054,7 @@ function New-CAMDeploymentInfo() {
     $camDeploymenRegInfo.Add("CAM_USER_BLOB_URI", "userStorageAccountUri")
     $camDeploymenRegInfo.Add("CAM_USER_STORAGE_ACCOUNT_NAME", "userStorageName")
     $camDeploymenRegInfo.Add("CAM_USER_STORAGE_ACCOUNT_KEY", "userStorageAccountKey")
-    $camDeploymenRegInfo.Add("CAM_USER_BLOB_TOKEN", "userStorageAccountSaasToken")
+    $camDeploymenRegInfo.Add("CAM_USER_BLOB_TOKEN", "userStorageAccountSasToken")
 
 
     $authFileContent = @"
@@ -1291,12 +1291,12 @@ function New-ConnectionServiceDeployment() {
                 "secretName": "gatewaySubnet"
             }
         },
-        "CAMDeploymentBlobSource": {
+        "CAMBinariesSource": {
             "reference": {
                 "keyVault": {
                     "id": "$kvID"
                 },
-                "secretName": "CAMDeploymentBlobSource"
+                "secretName": "CAMBinariesSource"
             }
         },
         "certData": {
@@ -1438,7 +1438,7 @@ function New-CAMDeploymentRoot()
     $tenant = $spInfo.tenantId
     $registrationCode = $CAMConfig.parameters.cloudAccessRegistrationCode.value
     $artifactsLocation = $CAMConfig.parameters.artifactsLocation.clearValue
-    $CAMDeploymentBlobSource = $CAMConfig.parameters.CAMDeploymentBlobSource.clearValue
+    $CAMBinariesSource = $CAMConfig.parameters.CAMBinariesSource.clearValue
     
     $kvInfo = New-CAM-KeyVault `
         -RGName $RGName `
@@ -1460,7 +1460,7 @@ function New-CAMDeploymentRoot()
         -CAMConfig $CAMConfig `
         -artifactsLocation $artifactsLocation `
         -userDataStorageAccount	$userDataStorageAccount `
-        -CAMDeploymentBlobSource $CAMDeploymentBlobSource `
+        -CAMBinariesSource $CAMBinariesSource `
         -RGName $RGName `
         -kvInfo $kvInfo `
         -tempDir $tempDir | Out-Null
@@ -1517,7 +1517,7 @@ function Deploy-CAM() {
         $camSaasUri,
 
         [parameter(Mandatory = $true)] 
-        $CAMDeploymentBlobSource,
+        $CAMBinariesSource,
 
         [parameter(Mandatory = $true)] 
         $outputParametersFileName,
@@ -1580,9 +1580,9 @@ function Deploy-CAM() {
         value      = (ConvertTo-SecureString $domainName -AsPlainText -Force)
         clearValue = $domainName
     }
-    $CAMConfig.parameters.CAMDeploymentBlobSource = @{
-        value      = (ConvertTo-SecureString $CAMDeploymentBlobSource -AsPlainText -Force)
-        clearValue = $CAMDeploymentBlobSource
+    $CAMConfig.parameters.CAMBinariesSource = @{
+        value      = (ConvertTo-SecureString $CAMBinariesSource -AsPlainText -Force)
+        clearValue = $CAMBinariesSource
     }
     $CAMConfig.parameters.artifactsLocation = @{
         value      = (ConvertTo-SecureString $artifactsLocation -AsPlainText -Force)
@@ -1613,7 +1613,7 @@ function Deploy-CAM() {
     }
 
     # Set in Populate-UserBlob
-    $CAMConfig.parameters.userStorageAccountSaasToken = @{}
+    $CAMConfig.parameters.userStorageAccountSasToken = @{}
     $CAMConfig.parameters.userStorageAccountUri = @{}
     $CAMConfig.parameters.userStorageName = @{}
     $CAMConfig.parameters.userStorageAccountKey = @{}
@@ -1861,12 +1861,12 @@ function Deploy-CAM() {
         "gatewaySubnetName": {
             "value": "$($CAMConfig.internal.GWSubnetName)"
         },
-		"CAMDeploymentBlobSource": {
+		"CAMBinariesSource": {
 			"reference": {
 				"keyVault": {
 					"id": "$kvId"
 				},
-				"secretName": "CAMDeploymentBlobSource"
+				"secretName": "CAMBinariesSource"
 			}
 		},
 		"_artifactsLocation": {
@@ -2256,7 +2256,7 @@ else {
         -camSaasUri $camSaasUri.Trim().TrimEnd('/') `
         -verifyCAMSaaSCertificate $verifyCAMSaaSCertificate `
         -CAMDeploymentTemplateURI $CAMDeploymentTemplateURI `
-        -CAMDeploymentBlobSource $CAMDeploymentBlobSource.Trim().TrimEnd('/') `
+        -CAMBinariesSource $CAMBinariesSource.Trim().TrimEnd('/') `
         -outputParametersFileName $outputParametersFileName `
         -subscriptionId $selectedSubcriptionId `
         -RGName $rgMatch.ResourceGroupName `

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -323,12 +323,10 @@ function New-UserStorageAccount {
     return $acct
 }
 
-# is blobRWTemplateURI still needed - can pass in the userStorageAccountUri to agent ARM template
 function New-RemoteWorstationTemplates {
     param (
         $CAMConfig,
         $binaryLocation,
-        $blobRWTemplateUri,
         $kvId,
         $storageAccountContext,
         $storageAccountContainerName,
@@ -610,7 +608,6 @@ function Populate-UserBlob {
         New-RemoteWorstationTemplates `
             -CAMConfig $CAMConfig `
             -binaryLocation $binaryLocation `
-            -blobRWTemplateUri ($blobUri + 'remote-workstation') `
             -kvId $kvId `
             -storageAccountContext $ctx `
             -storageAccountContainerName $container_name `

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -381,6 +381,14 @@ function New-RemoteWorstationTemplates {
 				"secretName": "userStorageAccountUri"
 			}
         },
+        "userStorageAccountSasToken": {
+			"reference": {
+				"keyVault": {
+					"id": "$kvId"
+				},
+				"secretName": "userStorageAccountSasToken"
+			}
+		},
 		"userStorageAccountKey": {
 			"reference": {
 				"keyVault": {
@@ -431,15 +439,7 @@ function New-RemoteWorstationTemplates {
 			}
 		},
 		"domainToJoin": { "value": "$domainFQDN" },
-		"storageAccountName": { "value": "$VHDStorageAccountName" },
-		"userStorageAccountSasToken": {
-			"reference": {
-				"keyVault": {
-					"id": "$kvId"
-				},
-				"secretName": "userStorageAccountSasToken"
-			}
-		}
+		"storageAccountName": { "value": "$VHDStorageAccountName" }
 	}
 }
 
@@ -1914,6 +1914,14 @@ function Deploy-CAM() {
 				"secretName": "artifactsLocation"
 			}
         },
+        "userStorageAccountName": {
+			"reference": {
+				"keyVault": {
+				"id": "$kvId"
+				},
+				"secretName": "userStorageName"
+			}
+        },
         "userStorageAccountUri": {
 			"reference": {
 				"keyVault": {
@@ -1930,7 +1938,15 @@ function Deploy-CAM() {
 				"secretName": "userStorageAccountSasToken"
 			}
         },
-		"LocalAdminUsername": {
+        "userStorageAccountKey": {
+			"reference": {
+				"keyVault": {
+				"id": "$kvId"
+				},
+				"secretName": "userStorageAccountKey"
+			}
+		},
+        "LocalAdminUsername": {
 			"reference": {
 				"keyVault": {
 					"id": "$kvId"
@@ -2001,15 +2017,7 @@ function Deploy-CAM() {
 				},
 				"secretName": "cloudAccessRegistrationCode"
 			}
-        },
-        "userStorageAccountKey": {
-			"reference": {
-				"keyVault": {
-				"id": "$kvId"
-				},
-				"secretName": "userStorageAccountKey"
-			}
-		}
+        }
 	}
 }
 "@

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -146,6 +146,12 @@
         "description": "SAS token requried to access user's storage account"
       }
     },
+    "userStorageAccountKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "User's storage account key"
+      }
+    },
     "_artifactsLocation": {
       "type": "string",
       "metadata": {
@@ -331,6 +337,9 @@
           },
           "userStorageAccountSasToken": {
             "value": "[parameters('userStorageAccountSasToken')]"
+          },
+          "userStorageAccountKey": {
+            "value": "[parameters('userStorageAccountKey')]"
           },
           "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -134,6 +134,18 @@
         "description": "The location of the CAM binaries"
       }
     },
+    "userStorageAccountUri": {
+      "type": "string",
+      "metadata": {
+        "description": "The URI of the user's storage account"
+      }
+    },
+    "userStorageAccountSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SAS token requried to access user's storage account"
+      }
+    },
     "_artifactsLocation": {
       "type": "string",
       "metadata": {
@@ -314,8 +326,11 @@
           "AgentChannel": {
             "value": "[parameters('AgentChannel')]"
           },
-          "_artifactsLocation": {
-            "value": "[concat(parameters('_artifactsLocation'), '/remote-workstations')]"
+          "userStorageAccountUri": {
+            "value": "[parameters('userStorageAccountUri')]"
+          },
+          "userStorageAccountSasToken": {
+            "value": "[parameters('userStorageAccountSasToken')]"
           },
           "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -127,11 +127,11 @@
           "description": "Encoded blob of authorization and URL information for the CAM Connection Service."
       }
     },
-    "CAMDeploymentBlobSource": {
+    "CAMBinariesSource": {
       "type": "string",
       "defaultValue": "https://teradeploy.blob.core.windows.net/binaries",
       "metadata": {
-        "description": "The location of the blobs for admin GUI machine installation"
+        "description": "The location of the CAM binaries"
       }
     },
     "_artifactsLocation": {
@@ -189,7 +189,7 @@
               "value": "[parameters('gatewaySubnetName')]"
           },
           "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+            "value": "[parameters('CAMBinariesSource')]"
           },
           "_artifactsLocation": {
             "value": "[concat(parameters('_artifactsLocation'), '/root')]"
@@ -249,7 +249,7 @@
             "value": "[parameters('CAMDeploymentInfo')]"
           },
           "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+            "value": "[parameters('CAMBinariesSource')]"
           },
           "_baseArtifactsLocation": {
             "value": "[parameters('_artifactsLocation')]"
@@ -318,10 +318,10 @@
             "value": "[concat(parameters('_artifactsLocation'), '/remote-workstations')]"
           },
           "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+            "value": "[parameters('CAMBinariesSource')]"
           },
           "binaryLocation": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+            "value": "[parameters('CAMBinariesSource')]"
           }
         }
       }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -134,6 +134,12 @@
         "description": "The location of the CAM binaries"
       }
     },
+    "userStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the user's storage account"
+      }
+    },
     "userStorageAccountUri": {
       "type": "string",
       "metadata": {
@@ -331,6 +337,9 @@
           },
           "AgentChannel": {
             "value": "[parameters('AgentChannel')]"
+          },
+          "userStorageAccountName": {
+            "value": "[parameters('userStorageAccountName')]"
           },
           "userStorageAccountUri": {
             "value": "[parameters('userStorageAccountUri')]"

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -127,7 +127,7 @@
           "description": "Encoded blob of authorization and URL information for the CAM Connection Service."
       }
     },
-    "CAMBinariesSource": {
+    "binaryLocation": {
       "type": "string",
       "defaultValue": "https://teradeploy.blob.core.windows.net/binaries",
       "metadata": {
@@ -212,8 +212,8 @@
           "gatewaySubnetName": {
               "value": "[parameters('gatewaySubnetName')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           },
           "_artifactsLocation": {
             "value": "[concat(parameters('_artifactsLocation'), '/root')]"
@@ -272,8 +272,8 @@
           "CAMDeploymentInfo": {
             "value": "[parameters('CAMDeploymentInfo')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           },
           "_baseArtifactsLocation": {
             "value": "[parameters('_artifactsLocation')]"
@@ -350,8 +350,8 @@
           "userStorageAccountKey": {
             "value": "[parameters('userStorageAccountKey')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           }
         }
       }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -188,7 +188,7 @@
           "gatewaySubnetName": {
               "value": "[parameters('gatewaySubnetName')]"
           },
-          "CAMDeploymentBlobSource": {
+          "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"
           },
           "_artifactsLocation": {
@@ -248,7 +248,7 @@
           "CAMDeploymentInfo": {
             "value": "[parameters('CAMDeploymentInfo')]"
           },
-          "CAMDeploymentBlobSource": {
+          "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"
           },
           "_baseArtifactsLocation": {
@@ -317,10 +317,7 @@
           "_artifactsLocation": {
             "value": "[concat(parameters('_artifactsLocation'), '/remote-workstations')]"
           },
-          "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMBinariesSource')]"
-          },
-          "binaryLocation": {
+          "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"
           }
         }

--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -76,7 +76,7 @@
           "description": "The domain group the remote workstations should join"
       }
     },
-    "CAMBinariesSource": {
+    "binaryLocation": {
       "type": "string",
       "metadata": {
         "description": "The location of CAM binaries"
@@ -215,8 +215,8 @@
           "domainPassword": {
             "value": "[parameters('domainAdminPassword')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           },
           "_artifactsLocation": {
             "value": "[concat(variables('_artifactsLocation'), '/new-admin-vm')]"

--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -76,10 +76,10 @@
           "description": "The domain group the remote workstations should join"
       }
     },
-    "CAMDeploymentBlobSource": {
+    "CAMBinariesSource": {
       "type": "string",
       "metadata": {
-        "description": "The location of the blobs for admin GUI machine installation"
+        "description": "The location of CAM binaries"
       }
     },
     "_baseArtifactsLocation": {
@@ -215,8 +215,8 @@
           "domainPassword": {
             "value": "[parameters('domainAdminPassword')]"
           },
-          "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+          "CAMBinariesSource": {
+            "value": "[parameters('CAMBinariesSource')]"
           },
           "_artifactsLocation": {
             "value": "[concat(variables('_artifactsLocation'), '/new-admin-vm')]"

--- a/connection-service/new-admin-vm/new-admin-vm.json
+++ b/connection-service/new-admin-vm/new-admin-vm.json
@@ -32,10 +32,10 @@
                 "description": "Encoded blob of authorization and URL information for the CAM Connection Service."
             }
         },
-        "CAMDeploymentBlobSource": {
+        "CAMBinariesSource": {
             "type": "string",
             "metadata": {
-              "description": "The location of the blobs for admin GUI machine installation"
+              "description": "The location of the CAM binaries"
             }
         },
         "_artifactsLocation": {
@@ -72,14 +72,14 @@
                 "typeHandlerVersion": "2.9",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "modulesUrl": "[concat(parameters('CAMDeploymentBlobSource'),'/Install-ConnectionServer.ps1.zip')]",
+                    "modulesUrl": "[concat(parameters('CAMBinariesSource'),'/Install-ConnectionServer.ps1.zip')]",
                     "privacy": {
                         "DataCollection": "Disable"
                     },
                     "configurationFunction": "Install-ConnectionServer.ps1\\InstallConnectionServer",
                     "Properties": {
                         "remoteWorkstationDomainGroup": "[parameters('remoteWorkstationDomainGroup')]",
-                        "sourceURI": "[parameters('CAMDeploymentBlobSource')]",
+                        "sourceURI": "[parameters('CAMBinariesSource')]",
                         "DomainAdminCreds": {
                             "UserName": "[parameters('domainUsername')]",
                             "Password": "PrivateSettingsRef:DomainAdminPassword"

--- a/connection-service/new-admin-vm/new-admin-vm.json
+++ b/connection-service/new-admin-vm/new-admin-vm.json
@@ -32,7 +32,7 @@
                 "description": "Encoded blob of authorization and URL information for the CAM Connection Service."
             }
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
               "description": "The location of the CAM binaries"
@@ -72,14 +72,14 @@
                 "typeHandlerVersion": "2.9",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "modulesUrl": "[concat(parameters('CAMBinariesSource'),'/Install-ConnectionServer.ps1.zip')]",
+                    "modulesUrl": "[concat(parameters('binaryLocation'),'/Install-ConnectionServer.ps1.zip')]",
                     "privacy": {
                         "DataCollection": "Disable"
                     },
                     "configurationFunction": "Install-ConnectionServer.ps1\\InstallConnectionServer",
                     "Properties": {
                         "remoteWorkstationDomainGroup": "[parameters('remoteWorkstationDomainGroup')]",
-                        "sourceURI": "[parameters('CAMBinariesSource')]",
+                        "sourceURI": "[parameters('binaryLocation')]",
                         "DomainAdminCreds": {
                             "UserName": "[parameters('domainUsername')]",
                             "Password": "PrivateSettingsRef:DomainAdminPassword"

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -91,7 +91,7 @@
               "description": "Key to access user's storage account"
           }
       },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
                 "description": "Location of the CAM binaries."
@@ -117,7 +117,7 @@
         "windowsOSVersion": "2016-Datacenter",
         "apiVersion": "2015-06-15",
         "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
-        "pcoipAgentInstallerUrl": "[concat(parameters('CAMBinariesSource'),'/PCoIP_agent_release_installer_2.10.0.7600_standard.exe')]",
+        "pcoipAgentInstallerUrl": "[concat(parameters('binaryLocation'),'/PCoIP_agent_release_installer_2.10.0.7600_standard.exe')]",
         "videoDriverUrl": "",
         "registrationCode": "[parameters('registrationCode')]",
         "enableAutoShutdown" : false,
@@ -147,7 +147,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/rhel-standard-agent.json', parameters('userStorageAccountSasToken'))]",
+          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/server2016-standard-agent.json', parameters('userStorageAccountSasToken'))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -187,8 +187,8 @@
           "CAMDeploymentInfo": {
             "value": "[parameters('CAMDeploymentInfo')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           },
           "registrationCode": {
             "value": "[parameters('registrationCode')]"

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -66,6 +66,12 @@
                 "description": "Encoded blob of authorization and URL information for the CAM deployment"
             }
         },
+        "userStorageAccountName": {
+          "type": "string",
+          "metadata": {
+              "description": "The name of the user's storage account"
+          }
+        },
         "userStorageAccountUri": {
             "type": "string",
             "metadata": {
@@ -192,6 +198,9 @@
           },
           "AgentChannel": {
             "value": "[parameters('AgentChannel')]"
+          },
+          "userStorageAccountName": {
+            "value": "[parameters('userStorageAccountName')]"
           },
           "userStorageAccountUri": {
             "value": "[parameters('userStorageAccountUri')]"

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -77,7 +77,7 @@
             "metadata": {
                 "description": "SAS token to access user's storage account"
             },
-            "defaultValue": ""
+            "defaultValue": "?public"
         },
         "CAMBinariesSource": {
             "type": "string",
@@ -186,7 +186,14 @@
           },
           "AgentChannel": {
             "value": "[parameters('AgentChannel')]"
+          },
+          "userStorageAccountUri": {
+            "value": "[parameters('userStorageAccountUri')]"
+          },
+          "userStorageAccountSasToken": {
+            "value": "[parameters('userStorageAccountSasToken')]"
           }
+
         }
       }
     }

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -79,16 +79,10 @@
             },
             "defaultValue": ""
         },
-        "CAMDeploymentBlobSource": {
+        "CAMBinariesSource": {
             "type": "string",
             "metadata": {
-                "description": "Location of binary store primarily targeted towards remote-workstations."
-            }
-        },
-        "binaryLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the Teradici's binary store"
+                "description": "Location of the CAM binaries."
             }
         },
         "registrationCode": {
@@ -111,7 +105,7 @@
         "windowsOSVersion": "2016-Datacenter",
         "apiVersion": "2015-06-15",
         "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
-        "pcoipAgentInstallerUrl": "[concat(parameters('CAMDeploymentBlobSource'),'/PCoIP_agent_release_installer_2.10.0.7600_standard.exe')]",
+        "pcoipAgentInstallerUrl": "[concat(parameters('CAMBinariesSource'),'/PCoIP_agent_release_installer_2.10.0.7600_standard.exe')]",
         "videoDriverUrl": "",
         "registrationCode": "[parameters('registrationCode')]",
         "enableAutoShutdown" : false,
@@ -184,11 +178,8 @@
           "_artifactsLocation": {
             "value": "[concat(parameters('_artifactsLocation'), '/new-agent-vm')]"
           },
-          "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
-          },
-          "binaryLocation": {
-            "value": "[parameters('binaryLocation')]"
+          "CAMBinariesSource": {
+            "value": "[parameters('CAMBinariesSource')]"
           },
           "registrationCode": {
             "value": "[parameters('registrationCode')]"

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -66,16 +66,16 @@
                 "description": "Encoded blob of authorization and URL information for the CAM deployment"
             }
         },
-        "_artifactsLocation": {
+        "userStorageAccountUri": {
             "type": "string",
             "metadata": {
-                "description": "The location of resources, such as templates and DSC modules, that the template depends on"
+                "description": "The URI of the user's storage account"
             }
         },
-        "_artifactsLocationSasToken": {
+        "userStorageAccountSasToken": {
             "type": "securestring",
             "metadata": {
-                "description": "Auto-generated token to access _artifactsLocation"
+                "description": "SAS token to access user's storage account"
             },
             "defaultValue": ""
         },
@@ -135,7 +135,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('_artifactsLocation'), '/new-agent-vm/server2016-standard-agent.json', parameters('_artifactsLocationSasToken'))]",
+          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/server2016-standard-agent.json', parameters('userStorageAccountSasToken'))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -174,9 +174,6 @@
           },
           "CAMDeploymentInfo": {
             "value": "[parameters('CAMDeploymentInfo')]"
-          },
-          "_artifactsLocation": {
-            "value": "[concat(parameters('_artifactsLocation'), '/new-agent-vm')]"
           },
           "CAMBinariesSource": {
             "value": "[parameters('CAMBinariesSource')]"

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -135,7 +135,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/server2016-standard-agent.json', parameters('userStorageAccountSasToken'))]",
+          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/server2016-graphics-agent.json', parameters('userStorageAccountSasToken'))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -79,6 +79,12 @@
             },
             "defaultValue": "?public"
         },
+        "userStorageAccountKey": {
+          "type": "securestring",
+          "metadata": {
+              "description": "Key to access user's storage account"
+          }
+      },
         "CAMBinariesSource": {
             "type": "string",
             "metadata": {
@@ -192,6 +198,9 @@
           },
           "userStorageAccountSasToken": {
             "value": "[parameters('userStorageAccountSasToken')]"
+          },
+          "userStorageAccountKey": {
+            "value": "[parameters('userStorageAccountKey')]"
           }
 
         }

--- a/remote-workstations/azuredeploy.json
+++ b/remote-workstations/azuredeploy.json
@@ -135,7 +135,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/server2016-graphics-agent.json', parameters('userStorageAccountSasToken'))]",
+          "uri": "[concat(parameters('userStorageAccountUri'), 'remote-workstation-template/rhel-standard-agent.json', parameters('userStorageAccountSasToken'))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -111,7 +111,7 @@
         "userStorageAccountName": {
             "type": "string",
             "metadata": {
-                "description": "Storage account for user blob and custom templates"
+                "description": "Name of user's storage account"
             },
             "defaultValue": ""
         },
@@ -132,7 +132,7 @@
         "userStorageAccountKey": {
             "type": "securestring",
             "metadata": {
-                "description": "Storage account key for accessing private blob data"
+                "description": "Key for accessing user's storage account"
             }
         },
         "binaryLocation": {

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -81,16 +81,16 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "_artifactsLocation": {
+        "userStorageAccountUri": {
             "type": "string",
             "metadata": {
-                "description": "The location of resources, such as templates and DSC modules, that the template depends on"
+                "description": "The URI of the user's storage account"
             }
         },
-        "_artifactsLocationSasToken": {
+        "userStorageAccountSasToken": {
             "type": "securestring",
             "metadata": {
-                "description": "Auto-generated token to access _artifactsLocation"
+                "description": "SAS token for accesing user's storage account"
             },
             "defaultValue": "?public"
         },
@@ -256,7 +256,7 @@
                 "typeHandlerVersion": "2.0",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "fileUris": [ "[ concat(parameters('_artifactsLocation'), '/', variables('scriptFileName'))]" ]
+                    "fileUris": [ "[ concat(parameters('userStorageAccountUri'), 'remote-workstation','/', variables('scriptFileName'))]" ]
                 },
                 "protectedSettings": {
                     "commandToExecute": "[concat('bash ', variables('scriptFileName'), ' \"', parameters('registrationCode'), '\" \"', parameters('agentType'), '\" \"', variables('vmSettings').vmNamePrefix, '\" \"', parameters('domainToJoin'), '\" \"', parameters('domainUsername'), '\" \"', parameters('domainPassword'), '\" \"', parameters('domainGroupToJoin'), '\" \"', parameters('AgentChannel'), '\"')]",
@@ -279,7 +279,7 @@
                 "typeHandlerVersion": "1.4",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "fileUris": [ "[concat(parameters('_artifactsLocation'), '/', variables('idleShutdownScriptFileName'))]" ]
+                    "fileUris": [ "[concat(parameters('userStorageAccountUri'), 'remote-workstation','/', variables('idleShutdownScriptFileName'))]" ]
                 },
                 "protectedSettings": {
                     "commandToExecute": "[concat('sudo bash ', variables('idleShutdownScriptFileName'), ' -install')]",

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -134,6 +134,12 @@
                 "description": "Storage account key for accessing private blob data"
             }
         },
+        "CAMBinariesSource": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for CAN deployment binaries"
+            }
+        },
         "AgentChannel": {
             "type": "string",
             "metadata": {

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -81,19 +81,6 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "userStorageAccountUri": {
-            "type": "string",
-            "metadata": {
-                "description": "The URI of the user's storage account"
-            }
-        },
-        "userStorageAccountSasToken": {
-            "type": "securestring",
-            "metadata": {
-                "description": "SAS token for accesing user's storage account"
-            },
-            "defaultValue": "?public"
-        },
         "registrationCode": {
           "type": "securestring",
           "minLength": 21,
@@ -127,6 +114,20 @@
                 "description": "Storage account for user blob and custom templates"
             },
             "defaultValue": ""
+        },
+        "userStorageAccountUri": {
+            "type": "string",
+            "metadata": {
+                "description": "The URI of the user's storage account"
+            },
+            "defaultValue": ""
+        },
+        "userStorageAccountSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SAS token for accesing user's storage account"
+            },
+            "defaultValue": "?public"
         },
         "userStorageAccountKey": {
             "type": "securestring",

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -135,7 +135,7 @@
                 "description": "Storage account key for accessing private blob data"
             }
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
                 "description": "Location for CAN deployment binaries"

--- a/remote-workstations/new-agent-vm/rhel-standard-agent.json
+++ b/remote-workstations/new-agent-vm/rhel-standard-agent.json
@@ -94,18 +94,6 @@
             },
             "defaultValue": "?public"
         },
-        "binaryLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the blobs for admin GUI machine installation"
-            }
-        },
-        "CAMDeploymentBlobSource": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the blobs for end-user-application-vms"
-            }
-        },
         "registrationCode": {
           "type": "securestring",
           "minLength": 21,

--- a/remote-workstations/new-agent-vm/server2016-graphics-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-graphics-agent.json
@@ -83,14 +83,14 @@
         "userStorageAccountName": {
             "type": "string",
             "metadata": {
-                "description": "Storage account for user blob and custom templates"
+                "description": "Name of user's storage account"
             },
             "defaultValue": ""
         },
         "userStorageAccountKey": {
             "type": "securestring",
             "metadata": {
-                "description": "Storage account key for accessing private blob data"
+                "description": "Key for accessing user's storage account"
             },
             "defaultValue": ""
         },

--- a/remote-workstations/new-agent-vm/server2016-graphics-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-graphics-agent.json
@@ -107,7 +107,7 @@
             },
             "defaultValue": "?public"
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
                 "description": "The location of the blobs for admin GUI machine installation"
@@ -175,7 +175,7 @@
                 "videoDriverUrl": ""
             },
             "Graphics": {
-                "videoDriverUrl": "[concat(parameters('CAMBinariesSource'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
+                "videoDriverUrl": "[concat(parameters('binaryLocation'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
             }
         },
           

--- a/remote-workstations/new-agent-vm/server2016-graphics-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-graphics-agent.json
@@ -93,16 +93,16 @@
             },
             "defaultValue": "?public"
         },
-        "binaryLocation": {
+        "CAMBinariesSource": {
             "type": "string",
             "metadata": {
                 "description": "The location of the blobs for admin GUI machine installation"
             }
         },
-        "CAMDeploymentBlobSource": {
+        "blobRWTemplateUri": {
             "type": "string",
             "metadata": {
-                "description": "The location of the blobs for end-user-application-vms"
+                "description": "The location of the blobs in user storage account for remote workstation "
             }
         },
         "registrationCode": {
@@ -182,7 +182,7 @@
                 "videoDriverUrl": ""
             },
             "Graphics": {
-                "videoDriverUrl": "[concat(parameters('binaryLocation'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
+                "videoDriverUrl": "[concat(parameters('CAMBinariesSource'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
             }
         },
           
@@ -302,7 +302,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "configuration": {
-                "url": "[concat(parameters('CAMDeploymentBlobSource'), '/Install-PCoIPAgent.ps1.zip')]",
+                "url": "[concat(parameters('blobRWTemplateUri'), '/Install-PCoIPAgent.ps1.zip')]",
                 "script": "Install-PCoIPAgent.ps1",
                 "function": "InstallPCoIPAgent"
               },

--- a/remote-workstations/new-agent-vm/server2016-graphics-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-graphics-agent.json
@@ -80,16 +80,16 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "_artifactsLocation": {
+        "userStorageAccountUri": {
             "type": "string",
             "metadata": {
-                "description": "The location of resources, such as templates and DSC modules, that the template depends on"
+                "description": "URI of the user's storage account"
             }
         },
-        "_artifactsLocationSasToken": {
+        "userStorageAccountSasToken": {
             "type": "securestring",
             "metadata": {
-                "description": "Auto-generated token to access _artifactsLocation"
+                "description": "SAS token for accessing user's storage account"
             },
             "defaultValue": "?public"
         },
@@ -97,12 +97,6 @@
             "type": "string",
             "metadata": {
                 "description": "The location of the blobs for admin GUI machine installation"
-            }
-        },
-        "blobRWTemplateUri": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the blobs in user storage account for remote workstation "
             }
         },
         "registrationCode": {
@@ -157,7 +151,6 @@
 
         "apiVersion": "2015-06-15",
         "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
-        "sasToken": "[parameters('_artifactsLocationSasToken')]",
 
         "osSettings": {
             "Windows Server 2016": {
@@ -302,7 +295,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "configuration": {
-                "url": "[concat(parameters('blobRWTemplateUri'), '/Install-PCoIPAgent.ps1.zip')]",
+                "url": "[concat(parameters('userStorageAccountUri'), 'remote-workstation','/Install-PCoIPAgent.ps1.zip')]",
                 "script": "Install-PCoIPAgent.ps1",
                 "function": "InstallPCoIPAgent"
               },
@@ -318,7 +311,7 @@
               }
             },
             "protectedSettings": {
-              "configurationUrlSasToken": "[variables('sasToken')]",
+              "configurationUrlSasToken": "[parameters('userStorageAccountSasToken')]",
               "configurationArguments": {
                 "CAMDeploymentInfo": {
                     "userName": "dummyUser",
@@ -333,8 +326,8 @@
                     "Password": "[parameters('domainPassword')]"
                 },
                 "sasTokenAsCred": {
-                    "UserName": "[parameters('_artifactsLocation')]",
-                    "Password": "[variables('sasToken')]"
+                    "UserName": "[concat(parameters('userStorageAccountUri'), 'remote-workstation')]",
+                    "Password": "[parameters('userStorageAccountSasToken')]"
                 }
               }
             }

--- a/remote-workstations/new-agent-vm/server2016-graphics-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-graphics-agent.json
@@ -80,6 +80,20 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
+        "userStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Storage account for user blob and custom templates"
+            },
+            "defaultValue": ""
+        },
+        "userStorageAccountKey": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Storage account key for accessing private blob data"
+            },
+            "defaultValue": ""
+        },
         "userStorageAccountUri": {
             "type": "string",
             "metadata": {
@@ -125,20 +139,6 @@
                 "description": "Encoded blob of authorization and URL information for the CAM deployment"
             },
             "defaultValue": "null"
-        },
-        "userStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Storage account for user blob and custom templates"
-            },
-            "defaultValue": ""
-        },
-        "userStorageAccountKey": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Storage account key for accessing private blob data"
-            },
-            "defaultValue": ""
         },
         "AgentChannel": {
             "type": "string",

--- a/remote-workstations/new-agent-vm/server2016-standard-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-standard-agent.json
@@ -116,7 +116,7 @@
         "userStorageAccountName": {
             "type": "string",
             "metadata": {
-                "description": "Storage account for user blob and custom templates"
+                "description": "Name of user's storage account"
             },
             "defaultValue": ""
         },
@@ -135,7 +135,7 @@
         "userStorageAccountKey": {
             "type": "securestring",
             "metadata": {
-                "description": "Storage account key for accessing private blob data"
+                "description": "Key for acccessing user's storage account"
             },
             "defaultValue": ""
         },

--- a/remote-workstations/new-agent-vm/server2016-standard-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-standard-agent.json
@@ -80,7 +80,7 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
                 "description": "The location of the CAM binaries"
@@ -174,7 +174,7 @@
                 "videoDriverUrl": ""
             },
             "Graphics": {
-                "videoDriverUrl": "[concat(parameters('CAMBinariesSource'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
+                "videoDriverUrl": "[concat(parameters('binaryLocation'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
             }
         },
           

--- a/remote-workstations/new-agent-vm/server2016-standard-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-standard-agent.json
@@ -80,16 +80,16 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "_artifactsLocation": {
+        "userStorageAccountUri": {
             "type": "string",
             "metadata": {
-                "description": "The location of resources, such as templates and DSC modules, that the template depends on"
+                "description": "The URI of the user's storage account"
             }
         },
-        "_artifactsLocationSasToken": {
+        "userStorageAccountSasToken": {
             "type": "securestring",
             "metadata": {
-                "description": "Auto-generated token to access _artifactsLocation"
+                "description": "SAS token for accessing user's storage account"
             },
             "defaultValue": "?public"
         },
@@ -151,8 +151,7 @@
 
         "apiVersion": "2015-06-15",
         "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
-        "sasToken": "[parameters('_artifactsLocationSasToken')]",
-
+        
         "osSettings": {
             "Windows Server 2016": {
               "publisher": "MicrosoftWindowsServer",
@@ -296,7 +295,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "configuration": {
-                "url": "[concat(parameters('CAMBinariesSource'), '/Install-PCoIPAgent.ps1.zip')]",
+                "url": "[concat(parameters('userStorageAccountUri'), 'remote-workstation','/Install-PCoIPAgent.ps1.zip')]",
                 "script": "Install-PCoIPAgent.ps1",
                 "function": "InstallPCoIPAgent"
               },
@@ -312,7 +311,7 @@
               }
             },
             "protectedSettings": {
-              "configurationUrlSasToken": "[variables('sasToken')]",
+              "configurationUrlSasToken": "[parameters('userStorageAccountSasToken')]",
               "configurationArguments": {
                 "CAMDeploymentInfo": {
                     "userName": "dummyUser",
@@ -327,8 +326,8 @@
                     "Password": "[parameters('domainPassword')]"
                 },
                 "sasTokenAsCred": {
-                    "UserName": "[parameters('_artifactsLocation')]",
-                    "Password": "[variables('sasToken')]"
+                    "UserName": "[concat(parameters('userStorageAccountUri'), 'remote-workstation')]",
+                    "Password": "[parameters('userStorageAccountSasToken')]"
                 }
               }
             }

--- a/remote-workstations/new-agent-vm/server2016-standard-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-standard-agent.json
@@ -93,16 +93,10 @@
             },
             "defaultValue": "?public"
         },
-        "binaryLocation": {
+        "CAMBinariesSource": {
             "type": "string",
             "metadata": {
-                "description": "The location of the blobs for admin GUI machine installation"
-            }
-        },
-        "CAMDeploymentBlobSource": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the blobs for end-user-application-vms"
+                "description": "The location of the CAM binaries"
             }
         },
         "registrationCode": {
@@ -182,7 +176,7 @@
                 "videoDriverUrl": ""
             },
             "Graphics": {
-                "videoDriverUrl": "[concat(parameters('binaryLocation'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
+                "videoDriverUrl": "[concat(parameters('CAMBinariesSource'), '/370.12_grid_win10_server2016_64bit_international.exe')]"
             }
         },
           
@@ -302,7 +296,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "configuration": {
-                "url": "[concat(parameters('CAMDeploymentBlobSource'), '/Install-PCoIPAgent.ps1.zip')]",
+                "url": "[concat(parameters('CAMBinariesSource'), '/Install-PCoIPAgent.ps1.zip')]",
                 "script": "Install-PCoIPAgent.ps1",
                 "function": "InstallPCoIPAgent"
               },

--- a/remote-workstations/new-agent-vm/server2016-standard-agent.json
+++ b/remote-workstations/new-agent-vm/server2016-standard-agent.json
@@ -80,19 +80,6 @@
                 "description": "The password for the administrator account of the new VM and the domain"
             }
         },
-        "userStorageAccountUri": {
-            "type": "string",
-            "metadata": {
-                "description": "The URI of the user's storage account"
-            }
-        },
-        "userStorageAccountSasToken": {
-            "type": "securestring",
-            "metadata": {
-                "description": "SAS token for accessing user's storage account"
-            },
-            "defaultValue": "?public"
-        },
         "CAMBinariesSource": {
             "type": "string",
             "metadata": {
@@ -132,6 +119,18 @@
                 "description": "Storage account for user blob and custom templates"
             },
             "defaultValue": ""
+        },
+        "userStorageAccountUri": {
+            "type": "string",
+            "metadata": {
+                "description": "The URI of the user's storage account"
+            }
+        },
+        "userStorageAccountSasToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "SAS token for accessing user's storage account"
+            }
         },
         "userStorageAccountKey": {
             "type": "securestring",

--- a/root/azuredeploy.json
+++ b/root/azuredeploy.json
@@ -52,7 +52,7 @@
           "description": "The name of the subnet for application gateways in the virtual network."
       }
     },
-    "CAMBinariesSource": {
+    "binaryLocation": {
       "type": "string",
       "metadata": {
         "description": "The location of the blobs for admin GUI machine installation"
@@ -312,8 +312,8 @@
           "adminPassword": {
             "value": "[parameters('domainAdminPassword')]"
           },
-          "CAMBinariesSource": {
-            "value": "[parameters('CAMBinariesSource')]"
+          "binaryLocation": {
+            "value": "[parameters('binaryLocation')]"
           }
         }
       }

--- a/root/azuredeploy.json
+++ b/root/azuredeploy.json
@@ -52,7 +52,7 @@
           "description": "The name of the subnet for application gateways in the virtual network."
       }
     },
-    "CAMDeploymentBlobSource": {
+    "CAMBinariesSource": {
       "type": "string",
       "metadata": {
         "description": "The location of the blobs for admin GUI machine installation"
@@ -312,8 +312,8 @@
           "adminPassword": {
             "value": "[parameters('domainAdminPassword')]"
           },
-          "CAMDeploymentBlobSource": {
-            "value": "[parameters('CAMDeploymentBlobSource')]"
+          "CAMBinariesSource": {
+            "value": "[parameters('CAMBinariesSource')]"
           }
         }
       }

--- a/root/configure-dc-and-ca/configure-dc-and-ca.json
+++ b/root/configure-dc-and-ca/configure-dc-and-ca.json
@@ -26,7 +26,7 @@
                 "description": "The FQDN of the Active Directory Domain to be created. Must have a '.' like domain.local"
             }
         },
-        "CAMBinariesSource": {
+        "binaryLocation": {
             "type": "string",
             "metadata": {
               "description": "The location of the blobs for admin GUI machine installation"
@@ -45,7 +45,7 @@
                 "typeHandlerVersion": "2.19",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "modulesUrl": "[concat(parameters('CAMBinariesSource'),'/Install-DC-and-CA.ps1.zip')]",                    
+                    "modulesUrl": "[concat(parameters('binaryLocation'),'/Install-DC-and-CA.ps1.zip')]",                    
                     "configurationFunction": "Install-DC-and-CA.ps1\\CreateDCCA",
                     "Properties": {
                         "DomainName": "[parameters('domainName')]",

--- a/root/configure-dc-and-ca/configure-dc-and-ca.json
+++ b/root/configure-dc-and-ca/configure-dc-and-ca.json
@@ -26,7 +26,7 @@
                 "description": "The FQDN of the Active Directory Domain to be created. Must have a '.' like domain.local"
             }
         },
-        "CAMDeploymentBlobSource": {
+        "CAMBinariesSource": {
             "type": "string",
             "metadata": {
               "description": "The location of the blobs for admin GUI machine installation"
@@ -45,7 +45,7 @@
                 "typeHandlerVersion": "2.19",
                 "autoUpgradeMinorVersion": true,
                 "settings": {
-                    "modulesUrl": "[concat(parameters('CAMDeploymentBlobSource'),'/Install-DC-and-CA.ps1.zip')]",                    
+                    "modulesUrl": "[concat(parameters('CAMBinariesSource'),'/Install-DC-and-CA.ps1.zip')]",                    
                     "configurationFunction": "Install-DC-and-CA.ps1\\CreateDCCA",
                     "Properties": {
                         "DomainName": "[parameters('domainName')]",


### PR DESCRIPTION
Following parameter changes have been implemented:

- CAMDeploymentBlobSource has been removed from all templates. Only binaryLocation exists where the DSC configuration and the nvidia driver are sourced from.
- All artifactsLocation and artifactsLocationSasToken parameters from the remote-workstation templates have been removed. Only the userStorageAccountName, userStorageAccountUri, userStorageAccountSasToken and userStorageAccountKey parameters are used instead. The windows agents use the userStorageAccountUri and SasToken params whereas the linux agent uses the userStorageAccountName and Key params (same as before). 