### PR TITLE
Connection server does not join domain.

### DIFF
--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -112,8 +112,7 @@
     "appGwCSPoolName": "CSBackendPool",
     "appGwCSPoolID": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/applicationGateways/', variables('appGwName'), '/backendAddressPools/', variables('appGwCSPoolName'))]",
     "sgNsgName": "[concat('sgNSG',parameters('CSUniqueSuffix'))]",
-    "connectionServerName": "[concat('conn-srvr',parameters('CSUniqueSuffix'))]",
-    "connectionServerBrokerFQDN": "[concat(variables('connectionServerName'),'.',parameters('domainName'),':',variables('brokerPort'))]"
+    "connectionServerName": "[concat('conn-srvr',parameters('CSUniqueSuffix'))]"
 },
   "resources": [
     {
@@ -328,7 +327,7 @@
             "value": "[parameters('localAdminPassword')]"
           },
           "brokerFQDN": {
-            "value": "[variables('connectionServerBrokerFQDN')]"
+            "value": "[concat(reference('CreateConnectionServer').outputs.privateIp.value,':',variables('brokerPort'))]"
           },
           "enableSecurityGateway": {
             "value": "[parameters('enableSecurityGateway')]"

--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -226,6 +226,9 @@
           "domainPassword": {
             "value": "[parameters('domainServiceAccountPassword')]"
           },
+          "domainName": {
+            "value": "[parameters('domainName')]"
+          },
           "binaryLocation": {
             "value": "[parameters('binaryLocation')]"
           },

--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -191,6 +191,12 @@
           },
           "storageAccountName": {
             "value": "[variables('storageAccountName')]"
+          },
+          "_artifactsLocation": {
+            "value": "[concat(variables('_artifactsLocation'), '/new-vm-join-domain')]"
+          },
+          "_artifactsLocationSasToken": {
+            "value": "[parameters('_artifactsLocationSasToken')]"
           }
         }
       }

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -73,8 +73,15 @@ Configuration InstallConnectionServer
     )
 
     # Get DC information
+    # The alternate way is to do a nslookup for the dns srv record for: _ldap._tcp.dc._msdcs.<DOMAIN>
+
+    Write-Host "Looking for domain controllers found for domain $domainName"
     
-    $directoryContext = new-object 'System.DirectoryServices.ActiveDirectory.DirectoryContext'("domain", $domainName )
+    $adminUsername = $DomainAdminCreds.GetNetworkCredential().Username
+    $adminPassword = $DomainAdminCreds.GetNetworkCredential().Password
+
+    $directoryContext = new-object 'System.DirectoryServices.ActiveDirectory.DirectoryContext' `
+        ("domain", $domainName, $adminUsername, $adminPassword)
     $dcs = [System.DirectoryServices.ActiveDirectory.DomainController]::FindAll($directoryContext)
    
     if($dcs.Count) {

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -999,6 +999,12 @@ brokerLocale=en_US
                     [System.Environment]::SetEnvironmentVariable($_.Name, $_.Value, "Machine")
                 }
 
+                # Setup primary domain search suffix to match the domain we're brokering
+                $networkRegKey = "HKLM:\System\CurrentControlSet\Services\Tcpip\Parameters"
+                
+                Set-ItemProperty -Path $networkRegKey -Name "Domain" -Type String -Value $using:domainName
+                Set-ItemProperty -Path $networkRegKey -Name "NV Domain" -Type String -Value $using:domainName
+
                 # Reboot machine to ensure all changes are picked up by all services.
                 $global:DSCMachineStatus = 1
             }

--- a/connection-service/new-admin-vm/new-admin-vm.json
+++ b/connection-service/new-admin-vm/new-admin-vm.json
@@ -26,6 +26,12 @@
                 "description": "Password of the account on the domain"
             }
         },
+        "domainName": {
+            "type": "string",
+            "metadata": {
+              "description": "The fully qualified domain name of the domain to connect to. The name must include a '.' such as example.com"
+            }
+        },
         "CAMDeploymentInfo": {
             "type": "securestring",
             "metadata": {
@@ -80,6 +86,7 @@
                     "Properties": {
                         "remoteWorkstationDomainGroup": "[parameters('remoteWorkstationDomainGroup')]",
                         "sourceURI": "[parameters('binaryLocation')]",
+                        "domainName": "[parameters('domainName')]",
                         "DomainAdminCreds": {
                             "UserName": "[parameters('domainUsername')]",
                             "Password": "PrivateSettingsRef:DomainAdminPassword"

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -199,30 +199,6 @@
                     }
                 }
             }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('dnsLabelPrefix'),'/joindomain')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "dependsOn": [
-                "[concat('Microsoft.Resources/deployments/',variables('nicName'),'-updateip')]"
-            ],
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "publisher": "Microsoft.Compute",
-                "type": "JsonADDomainExtension",
-                "typeHandlerVersion": "1.3",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                    "Name": "[parameters('domainToJoin')]",
-                    "User": "[concat(parameters('domainToJoin'), '\\', parameters('domainUsername'))]",
-                    "Restart": "true",
-                    "Options": "[parameters('domainJoinOptions')]"
-                },
-                "protectedsettings": {
-                    "Password": "[parameters('domainPassword')]"
-                }
-            }
         }
     ],
     "outputs": {

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -180,6 +180,9 @@
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('dnsLabelPrefix'),'/joindomain')]",
             "apiVersion": "[variables('apiVersion')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsLabelPrefix'))]"
+            ],
             "location": "[resourceGroup().location]",
             "properties": {
                 "publisher": "Microsoft.Compute",
@@ -195,17 +198,14 @@
                 "protectedsettings": {
                     "Password": "[parameters('domainPassword')]"
                 }
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsLabelPrefix'))]"
-            ]
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
             "name": "[concat(variables('nicName'),'-updateip')]",
             "apiVersion": "2015-01-01",
             "dependsOn": [
-              "[concat('Microsoft.Compute/virtualMachines/extensions/', parameters('dnsLabelPrefix'),'/joindomain')]"
+                "[concat(parameters('dnsLabelPrefix'),'/joindomain')]"
             ],
             "properties": {
               "mode": "Incremental",

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -105,12 +105,7 @@
                         "properties": {
                             "subnet": {
                                 "id": "[parameters('subnetId')]"
-                            },
-                            "ApplicationGatewayBackendAddressPools": [
-                                {
-                                    "id": "[parameters('applicationGatewayPoolReference')]"
-                                }
-                            ]
+                            }
                         }
                     }
                 ]
@@ -198,6 +193,9 @@
                     },
                     "privateIp": {
                         "value": "[reference(concat('Microsoft.Network/networkInterfaces/', variables('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+                    },
+                    "applicationGatewayPoolReference": {
+                        "value": "[parameters('applicationGatewayPoolReference')]"
                     }
                 }
             }

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -177,11 +177,37 @@
             ]
         },
         {
+            "type": "Microsoft.Resources/deployments",
+            "name": "[concat(variables('nicName'),'-updateip')]",
+            "apiVersion": "2015-01-01",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsLabelPrefix'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('updateipTemplateUri')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "nicName": {
+                        "value": "[variables('nicName')]"
+                    },
+                    "SubnetRef": {
+                        "value": "[parameters('subnetId')]"
+                    },
+                    "privateIp": {
+                        "value": "[reference(concat('Microsoft.Network/networkInterfaces/', variables('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+                    }
+                }
+            }
+        },
+        {
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('dnsLabelPrefix'),'/joindomain')]",
             "apiVersion": "[variables('apiVersion')]",
             "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsLabelPrefix'))]"
+                "[concat('Microsoft.Resources/deployments/',variables('nicName'),'-updateip')]"
             ],
             "location": "[resourceGroup().location]",
             "properties": {
@@ -199,33 +225,7 @@
                     "Password": "[parameters('domainPassword')]"
                 }
             }
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "name": "[concat(variables('nicName'),'-updateip')]",
-            "apiVersion": "2015-01-01",
-            "dependsOn": [
-                "[concat(parameters('dnsLabelPrefix'),'/joindomain')]"
-            ],
-            "properties": {
-              "mode": "Incremental",
-              "templateLink": {
-                "uri": "[variables('updateipTemplateUri')]",
-                "contentVersion": "1.0.0.0"
-              },
-              "parameters": {
-                "nicName": {
-                  "value": "[variables('nicName')]"
-                },
-                "SubnetRef": {
-                  "value": "[parameters('subnetId')]"
-                },
-                "privateIp": {
-                  "value": "[reference(concat('Microsoft.Network/networkInterfaces/', variables('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
-                }
-            }
         }
-    }
     ],
     "outputs": {
         "privateIp": {

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -76,7 +76,7 @@
         "imageOffer": "WindowsServer",
         "windowsOSVersion": "2016-Datacenter",
         "apiVersion": "2015-06-15",
-        "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
+        "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]"
     },
     "resources": [
         {
@@ -89,6 +89,7 @@
                     {
                         "name": "ipconfig",
                         "properties": {
+                            "privateIPAllocationMethod": "Static",
                             "subnet": {
                                 "id": "[parameters('subnetId')]"
                             },

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -69,14 +69,28 @@
             "metadata": {
                 "description": "Storage account to use for VM data and VHD's"
             }
-        }
-    },
+        },
+        "_artifactsLocation": {
+            "type": "string",
+            "metadata": {
+              "description": "The current URI of template evaluation"
+            }
+        },
+        "_artifactsLocationSasToken": {
+            "type": "securestring",
+            "metadata": {
+              "description": "Auto-generated token to access _artifactsLocation"
+            },
+            "defaultValue": ""
+          }   
+        },
     "variables": {
         "imagePublisher": "MicrosoftWindowsServer",
         "imageOffer": "WindowsServer",
         "windowsOSVersion": "2016-Datacenter",
         "apiVersion": "2015-06-15",
-        "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]"
+        "nicName": "[concat(parameters('dnsLabelPrefix'),'Nic')]",
+        "updateipTemplateUri": "[concat(parameters('_artifactsLocation'), '/update-nic.json', parameters('_artifactsLocationSasToken'))]"
     },
     "resources": [
         {
@@ -89,7 +103,6 @@
                     {
                         "name": "ipconfig",
                         "properties": {
-                            "privateIPAllocationMethod": "Static",
                             "subnet": {
                                 "id": "[parameters('subnetId')]"
                             },
@@ -186,6 +199,38 @@
             "dependsOn": [
                 "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsLabelPrefix'))]"
             ]
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "name": "[concat(variables('nicName'),'-updateip')]",
+            "apiVersion": "2015-01-01",
+            "dependsOn": [
+              "[concat('Microsoft.Compute/virtualMachines/extensions/', parameters('dnsLabelPrefix'),'/joindomain')]"
+            ],
+            "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                "uri": "[variables('updateipTemplateUri')]",
+                "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                "nicName": {
+                  "value": "[variables('nicName')]"
+                },
+                "SubnetRef": {
+                  "value": "[parameters('subnetId')]"
+                },
+                "privateIp": {
+                  "value": "[reference(concat('Microsoft.Network/networkInterfaces/', variables('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+                }
+            }
         }
-    ]
+    }
+    ],
+    "outputs": {
+        "privateIp": {
+            "type": "string",
+            "value": "[reference(variables('nicName')).ipConfigurations[0].properties.privateIPAddress]"
+        }
+    }
 }

--- a/connection-service/new-vm-join-domain/update-nic.json
+++ b/connection-service/new-vm-join-domain/update-nic.json
@@ -25,7 +25,7 @@
         "properties": {
           "ipConfigurations": [
             {
-              "name": "ipconfig1",
+              "name": "ipconfig",
               "properties": {
                 "privateIPAllocationMethod": "Static",
                 "privateIPAddress": "[parameters('privateIp')]",

--- a/connection-service/new-vm-join-domain/update-nic.json
+++ b/connection-service/new-vm-join-domain/update-nic.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "nicName": {
+          "type": "string"
+        },
+        "SubnetRef": {
+            "type": "string"
+        },
+        "privateIp": {
+          "type": "string"
+        }
+    },
+    "variables": {
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Network/networkInterfaces",
+        "name": "[parameters('nicName')]",
+        "apiVersion": "2015-06-15",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+        ],
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfig1",
+              "properties": {
+                "privateIPAllocationMethod": "Static",
+                "privateIPAddress": "[parameters('privateIp')]",
+                "subnet": {
+                  "id": "[parameters('SubnetRef')]"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "outputs": {}
+  }

--- a/connection-service/new-vm-join-domain/update-nic.json
+++ b/connection-service/new-vm-join-domain/update-nic.json
@@ -10,8 +10,14 @@
         },
         "privateIp": {
           "type": "string"
-        }
-    },
+        },
+        "applicationGatewayPoolReference": {
+          "type": "string",
+          "metadata": {
+              "description": "Application gateway backend pool this machine is a member of"
+          }
+      }
+  },
     "variables": {
     },
     "resources": [
@@ -31,7 +37,12 @@
                 "privateIPAddress": "[parameters('privateIp')]",
                 "subnet": {
                   "id": "[parameters('SubnetRef')]"
-                }
+                },
+                "ApplicationGatewayBackendAddressPools": [
+                  {
+                      "id": "[parameters('applicationGatewayPoolReference')]"
+                  }
+                ]
               }
             }
           ]

--- a/root/configure-dc-and-ca/Install-DC-and-CA.ps1
+++ b/root/configure-dc-and-ca/Install-DC-and-CA.ps1
@@ -29,30 +29,30 @@
         }
 
 
-	    WindowsFeature DNS 
+        WindowsFeature DNS 
         { 
             Ensure = "Present" 
             Name = "DNS"		
         }
 
-	    WindowsFeature RSAT
-	    {
-	        Ensure = "Present"
+        WindowsFeature RSAT
+        {
+            Ensure = "Present"
             Name = "RSAT"
-	    }
+        }
 
-	    WindowsFeature DnsTools
-	    {
-	        Ensure = "Present"
+        WindowsFeature DnsTools
+        {
+            Ensure = "Present"
             Name = "RSAT-DNS-Server"
-	    }
+        }
 
         xDnsServerAddress DnsServerAddress 
         { 
             Address        = '127.0.0.1' 
             InterfaceAlias = $InterfaceAlias
             AddressFamily  = 'IPv4'
-	        DependsOn = "[WindowsFeature]DNS","[WindowsFeature]RSAT","[WindowsFeature]DnsTools"
+            DependsOn = "[WindowsFeature]DNS","[WindowsFeature]RSAT","[WindowsFeature]DnsTools"
         }
 
         xWaitforDisk Disk2
@@ -60,22 +60,22 @@
              DiskNumber = 2
              RetryIntervalSec =$RetryIntervalSec
              RetryCount = $RetryCount
-	 		 #Make sure all the modules are installed before proceeding - this may not be needed...
-	 		 DependsOn = "[xDnsServerAddress]DnsServerAddress"
+             #Make sure all the modules are installed before proceeding - this may not be needed...
+             DependsOn = "[xDnsServerAddress]DnsServerAddress"
         }
 
         cDiskNoRestart ADDataDisk
         {
             DiskNumber = 2
             DriveLetter = "F"
-			DependsOn="[xWaitforDisk]Disk2"
+            DependsOn="[xWaitforDisk]Disk2"
         }
 
         WindowsFeature ADDSInstall 
         { 
             Ensure = "Present" 
             Name = "AD-Domain-Services"
-	        DependsOn="[cDiskNoRestart]ADDataDisk"
+            DependsOn="[cDiskNoRestart]ADDataDisk"
         } 
          
         xADDomain FirstDS 
@@ -86,7 +86,7 @@
             DatabasePath = "F:\NTDS"
             LogPath = "F:\NTDS"
             SysvolPath = "F:\SYSVOL"
-	        DependsOn = "[WindowsFeature]ADDSInstall","[xDnsServerAddress]DnsServerAddress"
+            DependsOn = "[WindowsFeature]ADDSInstall","[xDnsServerAddress]DnsServerAddress"
         }
 
         WindowsFeature ADCS-Cert-Authority
@@ -180,9 +180,9 @@
                 $file = New-Item "C:\rebootmarker" -type File
                 Set-Content -Path $file -Value "DSC reboot initiated"
 
-                # Reboot machine - still unclear if this is needed.
-				# $global:DSCMachineStatus = 1
-			}
-		}
-	}
+                # Reboot machine - needed to get DC into the right state to accept WinRM connections.
+                $global:DSCMachineStatus = 1
+            }
+        }
+    }
 }


### PR DESCRIPTION
CS get an auto-generated static IP through a two-step ARM template process.
CM uses IP based routing instead of DNS (since the name will be less deterministic after its not domain joined).
CS no-longer needs to remote-powershell to DC to get LDAPS certificate. (DC now always makes it before saying its done.)

Bonus: Fix up the password checking for the domain account in Deploy-CAM.ps1

This seemed like a good intermediate step to merge since it is working without any noticeable side-effects, and has a useful fix or two.