### PR TITLE
Expose idle shutdown time as script parameter

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -84,6 +84,11 @@ param(
     [String]
     $domainControllerOsType = "Windows Server 2016",
 
+    [parameter(Mandatory=$false)]
+    [ValidateRange(10,10000)]
+    [int]
+    $defaultIdleShutdownTime = 240,
+
     $camSaasUri = "https://cam.teradici.com",
     $CAMDeploymentTemplateURI = "https://raw.githubusercontent.com/teradici/deploy/master/azuredeploy.json",
     $binaryLocation = "https://teradeploy.blob.core.windows.net/binaries",
@@ -496,7 +501,7 @@ function New-RemoteWorkstationTemplates {
         "domainOrganizationUnitToJoin": { "value": "" },
         "agentType": { "value": "%agentType%" },
         "vmSize": { "value": "%vmSize%" },
-        "autoShutdownIdleTime" : { "value": 240 },
+        "autoShutdownIdleTime" : { "value": $defaultIdleShutdownTime },
         "AgentChannel": { "value": "$agentChannel"},
         "binaryLocation": { "value": "$binaryLocation" },
         "subnetID": { "value": "$($CAMConfig.parameters.remoteWorkstationSubnet.clearValue)" },
@@ -1876,7 +1881,12 @@ function Deploy-CAM() {
         [parameter(Mandatory=$false)]
         [ValidateSet("Windows Server 2016","Windows Server 2012R2")] 
         [String]
-        $domainControllerOsType = "Windows Server 2016"
+        $domainControllerOsType = "Windows Server 2016",
+
+        [parameter(Mandatory=$false)]
+        [ValidateRange(10,10000)]
+        [int]
+        $defaultIdleShutdownTime = 240
     )
 
     # Artifacts location 'folder' is where the template is stored
@@ -3052,6 +3062,7 @@ else {
             $registrationCode = $null
         }
     } while (-not $registrationCode )
+
     
     $claims = Get-Claims
 
@@ -3086,5 +3097,6 @@ else {
         -ownerTenantId $claims.tid `
         -ownerUpn $upn `
         -enableSecurityGateway $enableSecurityGateway `
-        -domainControllerOsType $domainControllerOsType
+        -domainControllerOsType $domainControllerOsType `
+        -defaultIdleShutdownTime $defaultIdleShutdownTime
 }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -212,8 +212,7 @@
     }
   },
   "variables": {
-    "adminDesktopVMName": "admin-rw",
-    "demoIdleShutdownTime": 20
+    "adminDesktopVMName": "admin-rw"
   },
   "resources": [
     {
@@ -409,9 +408,6 @@
           },
           "binaryLocation": {
             "value": "[parameters('binaryLocation')]"
-          },
-          "autoShutdownIdleTime" : {
-            "value": "[variables('demoIdleShutdownTime')]"
           }
         }
       }


### PR DESCRIPTION
FYI: the min and max range come from the values accepted by the Windows agent's idle shutdown service.