### PR TITLE
TSW-71918: Deploy-CAM.ps1 now takes to top entry for AzureRM and Azure

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2648,7 +2648,7 @@ function Confirm-ModuleVersion()
     $AzureRMModule = Get-Module -ListAvailable -Name "AzureRM"
     if ( $AzureRMModule ) {
         # have an AzureRM version - check that.
-        if ( [version]$AzureRMModule.Version.ToString() -lt [version]$MinAzureRMVersion) {
+        if ( [version]$AzureRMModule[0].Version.ToString() -lt [version]$MinAzureRMVersion) {
             Write-Host ("AzureRM module version must be equal or greater than " + $MinAzureRMVersion)
             return $false
         }
@@ -2663,7 +2663,7 @@ function Confirm-ModuleVersion()
             Write-Host ("Please install the Azure Command Line tools for Powershell from Microsoft. The Azure and AzureRM modules must be present.")
             return $false
         }
-        if ( [version]$AzureModule.Version.ToString() -lt [version]$MinAzureVersion) {
+        if ( [version]$AzureModule[0].Version.ToString() -lt [version]$MinAzureVersion) {
             Write-Host ("Azure module version must be equal or greater than " + $MinAzureVersion)
             return $false
         }

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2648,7 +2648,7 @@ function Confirm-ModuleVersion()
     $AzureRMModule = Get-Module -ListAvailable -Name "AzureRM"
     if ( $AzureRMModule ) {
         # have an AzureRM version - check that.
-        if ( [version]$AzureRMModule[0].Version.ToString() -lt [version]$MinAzureRMVersion) {
+        if (( $AzureRMModule.Version -ge [version]$MinAzureRMVersion) -eq $False) {
             Write-Host ("AzureRM module version must be equal or greater than " + $MinAzureRMVersion)
             return $false
         }
@@ -2663,7 +2663,7 @@ function Confirm-ModuleVersion()
             Write-Host ("Please install the Azure Command Line tools for Powershell from Microsoft. The Azure and AzureRM modules must be present.")
             return $false
         }
-        if ( [version]$AzureModule[0].Version.ToString() -lt [version]$MinAzureVersion) {
+        if (( $AzureModule.Version -ge [version]$MinAzureVersion) -eq $False) {
             Write-Host ("Azure module version must be equal or greater than " + $MinAzureVersion)
             return $false
         }

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2648,7 +2648,7 @@ function Confirm-ModuleVersion()
     $AzureRMModule = Get-Module -ListAvailable -Name "AzureRM"
     if ( $AzureRMModule ) {
         # have an AzureRM version - check that.
-        if (( $AzureRMModule.Version -ge [version]$MinAzureRMVersion) -eq $False) {
+        if (-not ( $AzureRMModule.Version -ge [version]$MinAzureRMVersion)) {
             Write-Host ("AzureRM module version must be equal or greater than " + $MinAzureRMVersion)
             return $false
         }
@@ -2663,7 +2663,7 @@ function Confirm-ModuleVersion()
             Write-Host ("Please install the Azure Command Line tools for Powershell from Microsoft. The Azure and AzureRM modules must be present.")
             return $false
         }
-        if (( $AzureModule.Version -ge [version]$MinAzureVersion) -eq $False) {
+        if (-not ( $AzureModule.Version -ge [version]$MinAzureVersion)) {
             Write-Host ("Azure module version must be equal or greater than " + $MinAzureVersion)
             return $false
         }


### PR DESCRIPTION
When doing the Confirm-ModuleVersion check AzureRM and Azure takes only the top entry of the object for the comparison. At this point $AzureRMModule and $AzureModule will have contents, so this should always return a result for comparison.