### PR TITLE
Premium storage and a couple other fixes

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -1489,7 +1489,7 @@ function New-ConnectionServiceDeployment() {
                 -SecretValue (ConvertTo-SecureString $connectionServiceNumber -AsPlainText -Force) `
                 -ErrorAction stop | Out-Null
             
-            Write-Host "Checking available resource group for connection service number $connectionServiceNumber"
+            Write-Host "Checking available resource group for connector number $connectionServiceNumber"
 
             $csRGName = $RGName + "-CN" + $connectionServiceNumber
             Set-AzureRMContext -Context $adminAzureContext | Out-Null

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -2082,6 +2082,14 @@ function Deploy-CAM() {
         clearValue = $artifactsLocation
     }
 
+    $CAMConfig.parameters.enableAddUser = @{
+        value      = if($deployOverDC) {
+            ConvertTo-SecureString "FALSE" -AsPlainText -Force
+        } else {
+            ConvertTo-SecureString "TRUE" -AsPlainText -Force
+        }
+    }
+
     $CAMConfig.parameters.cloudAccessRegistrationCode = @{value = $registrationCode}
 
     $CAMConfig.parameters.domainServiceAccountPassword = @{value = $domainAdminCredential.Password}
@@ -3496,15 +3504,6 @@ else {
             Write-Host "Using the virtual network location $vnetLocation"
         }
         $location = $vnetlocation
-    }
-
-    $CAMConfig.parameters.enableAddUser = @{
-        value      = if($deployOverDC) 
-        {
-            ConvertTo-SecureString "FALSE" -AsPlainText -Force
-        } else {
-            ConvertTo-SecureString "TRUE" -AsPlainText -Force
-        }
     }
 
     # Find the CAM root RG.

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -3498,6 +3498,15 @@ else {
         $location = $vnetlocation
     }
 
+    $CAMConfig.parameters.enableAddUser = @{
+        value      = if($deployOverDC) 
+        {
+            ConvertTo-SecureString "FALSE" -AsPlainText -Force
+        } else {
+            ConvertTo-SecureString "TRUE" -AsPlainText -Force
+        }
+    }
+
     # Find the CAM root RG.
     $resourceGroups = Get-AzureRmResourceGroup
 

--- a/connection-service/azuredeploy.json
+++ b/connection-service/azuredeploy.json
@@ -165,7 +165,7 @@
             "value": "[variables('connectionServerName')]"
           },
           "vmSize": {
-            "value": "Standard_A2_v2"
+            "value": "Standard_DS1_v2"
           },
           "domainToJoin": {
             "value": "[parameters('domainName')]"

--- a/connection-service/new-cm-sg-ls-vm/azuredeploy.json
+++ b/connection-service/new-cm-sg-ls-vm/azuredeploy.json
@@ -4,7 +4,6 @@
     "parameters": {
 	    "vmSku": {
 	      "type": "string",
-	      "defaultValue": "Standard_A2_v2",
 	      "metadata": {
 	        "description": "Size of VMs in the VM Scale Set."
 	      }

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -112,7 +112,7 @@
         {
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('dnsLabelPrefix')]",
-            "apiVersion": "2017-03-30",
+            "apiVersion": "2017-12-01",
             "location": "[resourceGroup().location]",
             "properties": {
                 "hardwareProfile": {
@@ -133,8 +133,7 @@
                     "osDisk": {
                         "name": "[concat(parameters('dnsLabelPrefix'), '-os')]",
                         "caching": "ReadWrite",
-                        "createOption": "FromImage",
-                        "storageAccountType": "Premium_LRS"
+                        "createOption": "FromImage"
                     },
                     "dataDisks": [ ]
                 },

--- a/connection-service/new-vm-join-domain/new-vm-join-domain.json
+++ b/connection-service/new-vm-join-domain/new-vm-join-domain.json
@@ -133,7 +133,8 @@
                     "osDisk": {
                         "name": "[concat(parameters('dnsLabelPrefix'), '-os')]",
                         "caching": "ReadWrite",
-                        "createOption": "FromImage"
+                        "createOption": "FromImage",
+                        "storageAccountType": "Premium_LRS"
                     },
                     "dataDisks": [ ]
                 },


### PR DESCRIPTION
- change the connection server to a DS1 image type with premium storage and higher SLA from Azure. Single core VM with ~4 Gbytes of RAM should be good for our cases here. Customers can bump up if they have high scale system. 
- fix some prompting
- added 'enableAddUser' key vault secret so that in domain-joined scenarios, the 'Add user' button can be disabled - we don't want to add users to customer domain controllers. Management interface changes for that will be in subsequent PR from PrimeSoft.