### PR TITLE
TSW 71902 gracefully fail on vCPU quota limits

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -3012,7 +3012,7 @@ function Write-Host-Warning() {
     Write-Host ("`n$message") -ForegroundColor Red
 }
 
-# Check resource group location for cores, if less than 7 exit the launch
+# Check resource group location for cores, if less than $neededCores exit the launch
 function Check-Location-Cores() {
     param(
         [parameter(Mandatory=$true)]

--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -3487,7 +3487,6 @@ $vnetConfig.RWsubnetName = $RemoteWorkstationSubnetName
 # Set the minimum vCPUs needed for a full deployment or an add-on connection
 $minCoresFullDeploy = 6
 $minCoresAddConn = 3
-$isExistingDC = $false
 
 # Get the user's subscription
 $rmContext = Get-AzureRmContext


### PR DESCRIPTION
There are 8 cases when going through this code that are captured:
3682 - existing deploy, same region [3 cores]
3099 - existing deploy, new region [3 cores]
3814 - new deploy, existing domain, existing rg, entered # [3 cores]
	   new deploy, new domain, existing rg, entered # [6 cores]
3824 - new deploy, existing domain, existing rg, entered name [3 cores]
	   new deploy, new domain, existing rg, entered name [6 cores]
3851 - new deploy, new domain, new rg [6 cores]
           new deploy, existing domain, new rg [3 cores]	

The locations are placed to preempt the creation of empty resource groups in Azure. 