### PR TITLE
Disable Secure Transfer for storage account:

### DIFF
--- a/Deploy-CAM.ps1
+++ b/Deploy-CAM.ps1
@@ -714,7 +714,8 @@ function New-UserStorageAccount {
         -ResourceGroupName $RGName `
         -AccountName $saName `
         -Location $location `
-        -SkuName "Standard_LRS"
+        -SkuName "Standard_LRS" `
+        -EnableHttpsTrafficOnly $false
 
     return $acct
 }


### PR DESCRIPTION
* Default has changed to require secure transfer for storage accounts, current version of the Management Interface does not support it so need to disable it explicitly