### PR TITLE
Upgrade-tomcat-to-fix-ghostcat-vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $container = New-AzureStorageContainer -Name <ContainerName> -Context $acct.Cont
     - Windows DSC script for provisioning Windows Remote Workstations: https://teradeploy.blob.core.windows.net/binaries/Install-PCoIPAgent.ps1.zip
     - Windows DSC script for provisioning a stand-alone Domain Controller for testing: https://teradeploy.blob.core.windows.net/binaries/Install-DC-and-CA.ps1.zip
     - Windows DSC script for provisioning Connection Server machine to run PCoIP Broker and Management Interface: https://teradeploy.blob.core.windows.net/binaries/Install-ConnectionServer.ps1.zip
-    - Apache Tomcat binary used for running PCoIP Broker and Management Interface: https://teradeploy.blob.core.windows.net/binaries/apache-tomcat-8.5.47-windows-x64.zip
+    - Apache Tomcat binary used for running PCoIP Broker and Management Interface: https://teradeploy.blob.core.windows.net/binaries/apache-tomcat-8.5.51-windows-x64.zip
     - NVIDIA Grid Driver for Windows: https://teradeploy.blob.core.windows.net/binaries/391.58_grid_win10_server2016_64bit_international.exe
     - NVIDIA Grid Driver for Linux: https://teradeploy.blob.core.windows.net/binaries/NVIDIA-Linux-x86_64-390.57-grid.run
     - Java 8 JDK Installer: https://teradeploy.blob.core.windows.net/binaries/jdk-8u144-windows-x64.exe
@@ -54,7 +54,7 @@ $binaries = @(
 "https://teradeploy.blob.core.windows.net/binaries/Install-PCoIPAgent.ps1.zip",
 "https://teradeploy.blob.core.windows.net/binaries/Install-DC-and-CA.ps1.zip",
 "https://teradeploy.blob.core.windows.net/binaries/Install-ConnectionServer.ps1.zip",
-"https://teradeploy.blob.core.windows.net/binaries/apache-tomcat-8.5.47-windows-x64.zip",
+"https://teradeploy.blob.core.windows.net/binaries/apache-tomcat-8.5.51-windows-x64.zip",
 "https://teradeploy.blob.core.windows.net/binaries/391.58_grid_win10_server2016_64bit_international.exe",
 "https://teradeploy.blob.core.windows.net/binaries/NVIDIA-Linux-x86_64-390.57-grid.run",
 "https://teradeploy.blob.core.windows.net/binaries/jdk-8u144-windows-x64.exe",

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -60,7 +60,7 @@ Configuration InstallConnectionServer
         $sumoConf = "sumo.conf",
 
         [string]
-        $tomcatInstaller = "apache-tomcat-8.5.47-windows-x64.zip",
+        $tomcatInstaller = "apache-tomcat-8.5.51-windows-x64.zip",
 
         [string]
         $brokerWAR = "pcoip-broker.war",
@@ -143,7 +143,7 @@ Configuration InstallConnectionServer
 
     #Tomcat locations
     $localtomcatpath = "$env:systemdrive\tomcat"
-    $CatalinaHomeLocation = "$localtomcatpath\apache-tomcat-8.5.47"
+    $CatalinaHomeLocation = "$localtomcatpath\apache-tomcat-8.5.51"
     $CatalinaBinLocation = $CatalinaHomeLocation + "\bin"
 
     $brokerServiceName = "CAMBroker"

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -512,6 +512,8 @@ Configuration InstallConnectionServer
                         -Destination ($origServerXMLFile)
                 }
 
+                Set-Content -Path $serverXMLFile -Value (Get-Content -Path $serverXMLFile | Select-String -Pattern "AJP" -NotMatch)
+
                 #update server.xml file
                 $xml = [xml](Get-Content ($origServerXMLFile))
 

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -545,10 +545,14 @@ Configuration InstallConnectionServer
                     #ref child
                     $xml.Server.Service.Engine )
 
+                $protocol = "AJP/1.3"
+
+                ($xml.Server.Service.Connector | Where-Object { $protocol -eq $_.protocol }) | ForEach-Object {
+                    # Remove each node from its parent
+                    [void]$_.ParentNode.RemoveChild($_)
+                }
+
                 $xml.save($ServerXMLFile)
-
-                Set-Content -Path $ServerXMLFile -Value (Get-Content -Path $ServerXMLFile | Select-String -Pattern "AJP" -NotMatch)
-
 
 
                 Write-Host "Opening port 8443 and 8080"
@@ -907,10 +911,14 @@ ldapHost=ldaps://$domainControllerFQDN
                     #ref child
                     $xml.Server.Service.Engine )
 
+                $protocol = "AJP/1.3"
+
+                ($xml.Server.Service.Connector | Where-Object { $protocol -eq $_.protocol }) | ForEach-Object {
+                    # Remove each node from its parent
+                    [void]$_.ParentNode.RemoveChild($_)
+                }
+                
                 $xml.save($serverXMLFile)
-
-                Set-Content -Path $ServerXMLFile -Value (Get-Content -Path $ServerXMLFile | Select-String -Pattern "AJP" -NotMatch)
-
 
 
                 Write-Host "Opening port $using:brokerPort"

--- a/connection-service/new-admin-vm/Install-ConnectionServer.ps1
+++ b/connection-service/new-admin-vm/Install-ConnectionServer.ps1
@@ -512,8 +512,6 @@ Configuration InstallConnectionServer
                         -Destination ($origServerXMLFile)
                 }
 
-                Set-Content -Path $serverXMLFile -Value (Get-Content -Path $serverXMLFile | Select-String -Pattern "AJP" -NotMatch)
-
                 #update server.xml file
                 $xml = [xml](Get-Content ($origServerXMLFile))
 
@@ -548,6 +546,8 @@ Configuration InstallConnectionServer
                     $xml.Server.Service.Engine )
 
                 $xml.save($ServerXMLFile)
+
+                Set-Content -Path $ServerXMLFile -Value (Get-Content -Path $ServerXMLFile | Select-String -Pattern "AJP" -NotMatch)
 
 
 
@@ -908,6 +908,8 @@ ldapHost=ldaps://$domainControllerFQDN
                     $xml.Server.Service.Engine )
 
                 $xml.save($serverXMLFile)
+
+                Set-Content -Path $ServerXMLFile -Value (Get-Content -Path $ServerXMLFile | Select-String -Pattern "AJP" -NotMatch)
 
 
 


### PR DESCRIPTION
Update tomcat to version 8.5.51 to fix Ghostcat vulnerability
Apache Tomcat has officially released versions 9.0.31, 8.5.51, and 7.0.100 to fix this vulnerability.