### PR TITLE
Supress WALinuxAgent Update:

### DIFF
--- a/connection-service/new-cm-sg-ls-vm/cm_setup_0.1.sh
+++ b/connection-service/new-cm-sg-ls-vm/cm_setup_0.1.sh
@@ -127,7 +127,7 @@ case "$FOLDER_NAME" in
 esac
 
 # Exclude WALinuxAgent From updates in cm_setup script
-sed --expression="s|\(.*\)yum\s*update\(.*\)|\1yum update --exclude=WALinuxAgent\2|g" "$FOLDER_NAME"/cm_setup.sh
+sed --in-place --expression="s|\(.*\)yum\s*update\(.*\)|\1yum update --exclude=WALinuxAgent\2|g" "$FOLDER_NAME"/cm_setup.sh
 
 sh "$FOLDER_NAME"/cm_setup.sh
 

--- a/connection-service/new-cm-sg-ls-vm/cm_setup_0.1.sh
+++ b/connection-service/new-cm-sg-ls-vm/cm_setup_0.1.sh
@@ -126,6 +126,9 @@ case "$FOLDER_NAME" in
            ;;
 esac
 
+# Exclude WALinuxAgent From updates in cm_setup script
+sed --expression="s|\(.*\)yum\s*update\(.*\)|\1yum update --exclude=WALinuxAgent\2|g" "$FOLDER_NAME"/cm_setup.sh
+
 sh "$FOLDER_NAME"/cm_setup.sh
 
 service security_gateway stop


### PR DESCRIPTION
* exclude updating WALinuxAgent when installing boost dependency for CM/SG